### PR TITLE
Fix agenda page routing, add in featured speakers section

### DIFF
--- a/data/resources.json
+++ b/data/resources.json
@@ -126,7 +126,7 @@
     "previousYear": "Year"
   },
   "speakersBlock": {
-    "title": "Rockstar speakers",
+    "title": "Agenda highlights",
     "callToAction": {
       "label": "View all speakers",
       "link": "/speakers/"

--- a/data/settings.json
+++ b/data/settings.json
@@ -27,8 +27,8 @@
       "label": "Speakers"
     },
     {
-      "route": "agenda",
-      "permalink": "/agenda/",
+      "route": "schedule",
+      "permalink": "/schedule/",
       "label": "Agenda"
     },
     {
@@ -209,7 +209,7 @@
       "itemsCount": 3
     },
     "speakers": {
-      "itemsCount": 4
+      "itemsCount": 8
     },
     "previousSpeakers": {
       "itemsCount": 6

--- a/src/elements/speakers-block.html
+++ b/src/elements/speakers-block.html
@@ -189,8 +189,8 @@
               <text-truncate lines="1">
                 <h3 class="name">[[speaker.name]]</h3>
               </text-truncate>
-              <text-truncate lines="1">
-                <div class="origin">[[speaker.country]]</div>
+              <text-truncate lines="2">
+                <div class="origin">[[speaker.shortBio]]</div>
               </text-truncate>
             </div>
 
@@ -239,7 +239,7 @@
       _generateSpeakers(speakers) {
         const filteredSpeakers = this.speakers
           .filter((speaker) => speaker.featured);
-        this.set('featuredSpeakers', this.randomOrder(filteredSpeakers).slice(0, 4));
+        this.set('featuredSpeakers', this.randomOrder(filteredSpeakers).slice(0, 8));
       }
     }
 

--- a/src/hoverboard-app.html
+++ b/src/hoverboard-app.html
@@ -208,7 +208,7 @@
             route="[[subroute]]"
           ></blog-page>
           <schedule-page
-            data-route="agenda"
+            data-route="schedule"
             data-path="pages/schedule-page.html"
             route="[[subroute]]"
             query-params="[[queryParams]]"

--- a/src/pages/home-page.html
+++ b/src/pages/home-page.html
@@ -182,7 +182,7 @@
  -->      </div>
     </hero-block>
     <about-block></about-block>
-<!--     <speakers-block></speakers-block> -->    
+    <speakers-block></speakers-block>    
      <tickets-block></tickets-block>
     <call-for-papers-block></call-for-papers-block>
     <subscribe-block></subscribe-block>
@@ -192,8 +192,8 @@
     <featured-videos></featured-videos>    
  --> 
     <latest-posts-block></latest-posts-block>
-    <map-block></map-block>
-    <partners-block></partners-block>
+<!--     <map-block></map-block>
+ -->    <partners-block></partners-block>
     <footer-block></footer-block>
   </template>
 


### PR DESCRIPTION
My last change to switch over to the graphical schedule introduced a problem with schedule sub-routes (Jen Morone happened to be up to catch it luckily!) 

I'm just going to push this so you don't get broken changes. 