### PR TITLE
Disable firestore persistence.

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,11 +126,7 @@
           messagingSenderId: '{$ firebase.messagingSenderId $}',
         });
 
-        firebase.firestore()
-          .enablePersistence({ experimentalTabSynchronization: true })
-          .catch(() => {
-            console.warn('DB offline support not available'); // eslint-disable-line no-console
-          });
+        firebase.firestore();
 
         // eslint-disable-next-line no-console
         console.log('Firebase App is ready!');


### PR DESCRIPTION
Seems like Firestore 5.5 is remaining cached on some devices despite my best efforts, and so it's still causing some annoying IndexedDb issues.